### PR TITLE
Remove breaking changes to case and when

### DIFF
--- a/exercises/practice/atbash-cipher/.meta/src/example.art
+++ b/exercises/practice/atbash-cipher/.meta/src/example.art
@@ -39,18 +39,14 @@ decode: function[phrase][
 
 
 letter?: function [chr][
-    or? in? chr 'a' .. 'z' in? chr 'A' .. 'Z'
+    in? chr alphabet.lower.upper'en
 ]
 
 punctuation?: function [chr][
-    case [chr]
-        when? [ caseIn? '!' .. '/' ] -> return true
-        when? [ caseIn? ':' .. '@' ] -> return true
-        when? [ caseIn? '[' .. '`' ] -> return true
-        when? [ caseIn? '{' .. '~' ] -> return true
-        else -> return false
-]
-
-caseIn?: function [range chr][
-    in? chr range
+    any? @[
+        in? chr '!' .. '/'
+        in? chr ':' .. '@'
+        in? chr '[' .. '`'
+        in? chr '{' .. '~'
+    ]
 ]

--- a/exercises/practice/binary-search/.meta/src/example.art
+++ b/exercises/practice/binary-search/.meta/src/example.art
@@ -5,10 +5,11 @@ find: function [values value][
     while [=< start stop] [
         i: div start + stop 2
         elt: values\[i]
-        case [value]
-            when? [> elt] -> start: i + 1
-            when? [< elt] -> stop: i - 1
-            else  -> return i
+        when.has: values\[i] [
+            [> elt] -> start: i + 1
+            [< elt] -> stop: i - 1
+            true  -> return i
+        ]
     ]
 
     null

--- a/exercises/practice/binary-search/.meta/src/example.art
+++ b/exercises/practice/binary-search/.meta/src/example.art
@@ -5,7 +5,7 @@ find: function [values value][
     while [=< start stop] [
         i: div start + stop 2
         elt: values\[i]
-        when.has: values\[i] [
+        when.has: value [
             [> elt] -> start: i + 1
             [< elt] -> stop: i - 1
             true  -> return i
@@ -14,4 +14,3 @@ find: function [values value][
 
     null
 ]
-

--- a/exercises/practice/secret-handshake/.meta/src/example.art
+++ b/exercises/practice/secret-handshake/.meta/src/example.art
@@ -3,12 +3,13 @@ commands: function [number][
     digits: reverse pad.with:'0' as.binary number 5
     loop.with:'i digits 'digit [
         unless digit <> '1' ->
-            case [i]
-                when? [= 0] -> append 'actions "wink"
-                when? [= 1] -> append 'actions "double blink"
-                when? [= 2] -> append 'actions "close your eyes"
-                when? [= 3] -> append 'actions "jump"
-                when? [= 4] -> reverse 'actions
+            case i [
+                0 -> append 'actions "wink"
+                1 -> append 'actions "double blink"
+                2 -> append 'actions "close your eyes"
+                3 -> append 'actions "jump"
+                4 -> reverse 'actions
+            ]
     ]
 
     actions


### PR DESCRIPTION
While looking through recent CI runs, I noticed a breakage revolving around this exercise. There were breaking changes to `case` four days ago so I swapped this out for `any?`. I also cleaned up the `letter?` helper function slightly.