### PR TITLE
Update track documentation

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,6 +1,6 @@
 # Installation
 
-Arturo comes with pre-built binaries for Linux, MacOS, and Windows in `full', `mini`, and `safe` build flavors.
+Arturo comes with pre-built binaries for Linux, MacOS, and Windows in `full`, `mini`, and `safe` build flavors.
 For this track, we'll be using [the nightly `full` build release of Arturo][nightly] which includes the entire standard library and mostly notably package manager support.
 
 For further assistance installing Arturo, please consult the [official Arturo Discord][discord].

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -26,7 +26,7 @@ There will also be one or more assertions comparing an expected value (on the le
 For example, the following code is a reduced test suite for the Leap exercise.
 
 ```arturo
-import.version:1.1.2 {unitt}!
+import {unitt}!
 import {src/leap}!
 
 suite "Leap" [


### PR DESCRIPTION
This reverts a recent change to the testing documentations to try and troubleshoot https://forum.exercism.org/t/arturo-tests-page-returning-500-error-page/16039/2. I'm also fixing a minor Markdown formatting issue with the installation docs.