### PR TITLE
Unskip RSpec tests in CI

### DIFF
--- a/bin/verify-exercises
+++ b/bin/verify-exercises
@@ -31,7 +31,7 @@ copy_example_or_examplar_to_solution() {
 
 unskip_tests() {
     jq -r '.files.test[]' .meta/config.json | while read -r test_file; do
-        sed -i 's/test.skip/test/g' "${test_file}"
+        sed -i -E 's/(test|it).skip/\1/g' "${test_file}"
     done
 }
 


### PR DESCRIPTION
The newer RSpec-like API uses `it` and `it.skip` where the original XUnit-like API uses `test` and `test.skip`. I'm migrating the exercises over to the new API so this change will make sure all tests are run regardless of which API is used.