### PR TITLE
 [RSpec-Like API Update] Exercise Batch 10

### DIFF
--- a/exercises/practice/tournament/.docs/instruction.append.md
+++ b/exercises/practice/tournament/.docs/instruction.append.md
@@ -1,5 +1,14 @@
 # Instructions append
 
+## Use of the medium vertical bar
+
+~~~~exercism/caution
+In Arturo, `|` is the pipe operator for reversing the default right to left order of function calls.
+In v2 of the Unitt testing framework, there is currently an issue where instances of `|` are being unexpectedly evaluated inside strings.
+Therefore, we've replaced `|` (vertical bar) with `❙` (medium vertical bar) in the expected outputs.
+We're in the process of upgrading the track to Unitt v3 where this issue is fixed. Then we'll revert back to the expected `|` (vertical bar) delimiter.
+~~~~
+
 ## Some notes about Arturo strings
 
 You'll see some syntax in the tests that may be new to you: multiline strings enclosed in `{ braces }`.

--- a/exercises/practice/tournament/.meta/src/example.art
+++ b/exercises/practice/tournament/.meta/src/example.art
@@ -1,6 +1,6 @@
 tally: function [input][
     fmt: function [team][
-        join.with:" | " @[
+        join.with:" ❙ " @[
             (pad.right team\name 30)
             (pad to :string team\mp 2)
             (pad to :string team\w 2)

--- a/exercises/practice/tournament/tests/test-tournament.art
+++ b/exercises/practice/tournament/tests/test-tournament.art
@@ -1,164 +1,174 @@
 import.version:2.0.1 {unitt}!
 import {src/tournament}!
 
-suite "Tournament" [
-    test "just the header if no input" [
-        actual: tally ""
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-        }
-        assert -> actual = expected
+describe "Tournament" [
+    it "just the header if no input" [
+        expects.be:'equal? @[
+            express "Team                           | MP |  W |  D |  L |  P"
+            express tally ""
+        ]
     ]
 
-    test.skip "a win is three points, a loss is zero points" [
-        actual: tally "Allegoric Alaskans;Blithering Badgers;win"
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
-            Blithering Badgers             |  1 |  0 |  0 |  1 |  0
-        }
-        assert -> actual = expected
+    it.skip "a win is three points, a loss is zero points" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+                Blithering Badgers             |  1 |  0 |  0 |  1 |  0
+            }
+            express tally "Allegoric Alaskans;Blithering Badgers;win"
+        ]
     ]
 
-    test.skip "a win can also be expressed as a loss" [
-        actual: tally "Blithering Badgers;Allegoric Alaskans;loss"
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
-            Blithering Badgers             |  1 |  0 |  0 |  1 |  0
-        }
-        assert -> actual = expected
+    it.skip "a win can also be expressed as a loss" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+                Blithering Badgers             |  1 |  0 |  0 |  1 |  0
+            }
+            express tally "Blithering Badgers;Allegoric Alaskans;loss"
+        ]
     ]
 
-    test.skip "a different team can win" [
-        actual: tally "Blithering Badgers;Allegoric Alaskans;win"
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Blithering Badgers             |  1 |  1 |  0 |  0 |  3
-            Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0
-        }
-        assert -> actual = expected
+    it.skip "a different team can win" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Blithering Badgers             |  1 |  1 |  0 |  0 |  3
+                Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0
+            }
+            express tally "Blithering Badgers;Allegoric Alaskans;win"
+        ]
     ]
 
-    test.skip "a draw is one point each" [
-        actual: tally "Allegoric Alaskans;Blithering Badgers;draw"
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1
-            Blithering Badgers             |  1 |  0 |  1 |  0 |  1
-        }
-        assert -> actual = expected
+    it.skip "a draw is one point each" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1
+                Blithering Badgers             |  1 |  0 |  1 |  0 |  1
+            }
+            express tally "Allegoric Alaskans;Blithering Badgers;draw"
+        ]
     ]
 
-    test.skip "There can be more than one match" [
-        actual: tally {
-            Allegoric Alaskans;Blithering Badgers;win
-            Allegoric Alaskans;Blithering Badgers;win
-        }
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
-            Blithering Badgers             |  2 |  0 |  0 |  2 |  0
-        }
-        assert -> actual = expected
+    it.skip "There can be more than one match" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+                Blithering Badgers             |  2 |  0 |  0 |  2 |  0
+            }
+            express tally {
+                Allegoric Alaskans;Blithering Badgers;win
+                Allegoric Alaskans;Blithering Badgers;win
+            }
+        ]
     ]
 
-    test.skip "There can be more than one winner" [
-        actual: tally {
-            Allegoric Alaskans;Blithering Badgers;loss
-            Allegoric Alaskans;Blithering Badgers;win
-        }
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3
-            Blithering Badgers             |  2 |  1 |  0 |  1 |  3
-        }
-        assert -> actual = expected
+    it.skip "There can be more than one winner" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3
+                Blithering Badgers             |  2 |  1 |  0 |  1 |  3
+            }
+            express tally {
+                Allegoric Alaskans;Blithering Badgers;loss
+                Allegoric Alaskans;Blithering Badgers;win
+            }
+        ]
     ]
 
-    test.skip "There can be more than two teams" [
-        actual: tally {
-            Allegoric Alaskans;Blithering Badgers;win
-            Blithering Badgers;Courageous Californians;win
-            Courageous Californians;Allegoric Alaskans;loss
-        }
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
-            Blithering Badgers             |  2 |  1 |  0 |  1 |  3
-            Courageous Californians        |  2 |  0 |  0 |  2 |  0
-        }
-        assert -> actual = expected
+    it.skip "There can be more than two teams" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+                Blithering Badgers             |  2 |  1 |  0 |  1 |  3
+                Courageous Californians        |  2 |  0 |  0 |  2 |  0
+            }
+            express tally {
+                Allegoric Alaskans;Blithering Badgers;win
+                Blithering Badgers;Courageous Californians;win
+                Courageous Californians;Allegoric Alaskans;loss
+            }
+        ]
     ]
 
-    test.skip "typical input" [
-        actual: tally {
-            Allegoric Alaskans;Blithering Badgers;win
-            Devastating Donkeys;Courageous Californians;draw
-            Devastating Donkeys;Allegoric Alaskans;win
-            Courageous Californians;Blithering Badgers;loss
-            Blithering Badgers;Devastating Donkeys;loss
-            Allegoric Alaskans;Courageous Californians;win
-        }
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
-            Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
-            Blithering Badgers             |  3 |  1 |  0 |  2 |  3
-            Courageous Californians        |  3 |  0 |  1 |  2 |  1
-        }
-        assert -> actual = expected
+    it.skip "typical input" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+                Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+                Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+                Courageous Californians        |  3 |  0 |  1 |  2 |  1
+            }
+            express tally {
+                Allegoric Alaskans;Blithering Badgers;win
+                Devastating Donkeys;Courageous Californians;draw
+                Devastating Donkeys;Allegoric Alaskans;win
+                Courageous Californians;Blithering Badgers;loss
+                Blithering Badgers;Devastating Donkeys;loss
+                Allegoric Alaskans;Courageous Californians;win
+            }
+        ]
     ]
 
-    test.skip "incomplete competition (not all pairs have played)" [
-        actual: tally {
-            Allegoric Alaskans;Blithering Badgers;loss
-            Devastating Donkeys;Allegoric Alaskans;loss
-            Courageous Californians;Blithering Badgers;draw
-            Allegoric Alaskans;Courageous Californians;win
-        }
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
-            Blithering Badgers             |  2 |  1 |  1 |  0 |  4
-            Courageous Californians        |  2 |  0 |  1 |  1 |  1
-            Devastating Donkeys            |  1 |  0 |  0 |  1 |  0
-        }
-        assert -> actual = expected
+    it.skip "incomplete competition (not all pairs have played)" [ 
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+                Blithering Badgers             |  2 |  1 |  1 |  0 |  4
+                Courageous Californians        |  2 |  0 |  1 |  1 |  1
+                Devastating Donkeys            |  1 |  0 |  0 |  1 |  0
+            }
+            express tally {
+                Allegoric Alaskans;Blithering Badgers;loss
+                Devastating Donkeys;Allegoric Alaskans;loss
+                Courageous Californians;Blithering Badgers;draw
+                Allegoric Alaskans;Courageous Californians;win
+            }
+        ]
     ]
 
-    test.skip "ties broken alphabetically" [
-        actual: tally {
-            Courageous Californians;Devastating Donkeys;win
-            Allegoric Alaskans;Blithering Badgers;win
-            Devastating Donkeys;Allegoric Alaskans;loss
-            Courageous Californians;Blithering Badgers;win
-            Blithering Badgers;Devastating Donkeys;draw
-            Allegoric Alaskans;Courageous Californians;draw
-        }
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
-            Courageous Californians        |  3 |  2 |  1 |  0 |  7
-            Blithering Badgers             |  3 |  0 |  1 |  2 |  1
-            Devastating Donkeys            |  3 |  0 |  1 |  2 |  1
-        }
-        assert -> actual = expected
+    it.skip "ties broken alphabetically" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
+                Courageous Californians        |  3 |  2 |  1 |  0 |  7
+                Blithering Badgers             |  3 |  0 |  1 |  2 |  1
+                Devastating Donkeys            |  3 |  0 |  1 |  2 |  1
+            }
+            express tally {
+                Courageous Californians;Devastating Donkeys;win
+                Allegoric Alaskans;Blithering Badgers;win
+                Devastating Donkeys;Allegoric Alaskans;loss
+                Courageous Californians;Blithering Badgers;win
+                Blithering Badgers;Devastating Donkeys;draw
+                Allegoric Alaskans;Courageous Californians;draw
+            }
+        ]
     ]
 
-    test.skip "ensure points sorted numerically" [
-        actual: tally {
-            Devastating Donkeys;Blithering Badgers;win
-            Devastating Donkeys;Blithering Badgers;win
-            Devastating Donkeys;Blithering Badgers;win
-            Devastating Donkeys;Blithering Badgers;win
-            Blithering Badgers;Devastating Donkeys;win
-        }
-        expected: {
-            Team                           | MP |  W |  D |  L |  P
-            Devastating Donkeys            |  5 |  4 |  0 |  1 | 12
-            Blithering Badgers             |  5 |  1 |  0 |  4 |  3
-        }
-        assert -> actual = expected
+    it.skip "ensure points sorted numerically" [
+        expects.be:'equal? @[
+            express {
+                Team                           | MP |  W |  D |  L |  P
+                Devastating Donkeys            |  5 |  4 |  0 |  1 | 12
+                Blithering Badgers             |  5 |  1 |  0 |  4 |  3
+            }
+            express tally {
+                Devastating Donkeys;Blithering Badgers;win
+                Devastating Donkeys;Blithering Badgers;win
+                Devastating Donkeys;Blithering Badgers;win
+                Devastating Donkeys;Blithering Badgers;win
+                Blithering Badgers;Devastating Donkeys;win
+            }
+        ]
     ]
 ]

--- a/exercises/practice/tournament/tests/test-tournament.art
+++ b/exercises/practice/tournament/tests/test-tournament.art
@@ -4,7 +4,9 @@ import {src/tournament}!
 describe "Tournament" [
     it "just the header if no input" [
         expects.be:'equal? @[
-            express "Team                           | MP |  W |  D |  L |  P"
+            express {
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+            }
             express tally ""
         ]
     ]
@@ -12,9 +14,9 @@ describe "Tournament" [
     it.skip "a win is three points, a loss is zero points" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
-                Blithering Badgers             |  1 |  0 |  0 |  1 |  0
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  1 ❙  1 ❙  0 ❙  0 ❙  3
+                Blithering Badgers             ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
             }
             express tally "Allegoric Alaskans;Blithering Badgers;win"
         ]
@@ -23,9 +25,9 @@ describe "Tournament" [
     it.skip "a win can also be expressed as a loss" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
-                Blithering Badgers             |  1 |  0 |  0 |  1 |  0
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  1 ❙  1 ❙  0 ❙  0 ❙  3
+                Blithering Badgers             ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
             }
             express tally "Blithering Badgers;Allegoric Alaskans;loss"
         ]
@@ -34,9 +36,9 @@ describe "Tournament" [
     it.skip "a different team can win" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Blithering Badgers             |  1 |  1 |  0 |  0 |  3
-                Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Blithering Badgers             ❙  1 ❙  1 ❙  0 ❙  0 ❙  3
+                Allegoric Alaskans             ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
             }
             express tally "Blithering Badgers;Allegoric Alaskans;win"
         ]
@@ -45,9 +47,9 @@ describe "Tournament" [
     it.skip "a draw is one point each" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1
-                Blithering Badgers             |  1 |  0 |  1 |  0 |  1
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  1 ❙  0 ❙  1 ❙  0 ❙  1
+                Blithering Badgers             ❙  1 ❙  0 ❙  1 ❙  0 ❙  1
             }
             express tally "Allegoric Alaskans;Blithering Badgers;draw"
         ]
@@ -56,9 +58,9 @@ describe "Tournament" [
     it.skip "There can be more than one match" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
-                Blithering Badgers             |  2 |  0 |  0 |  2 |  0
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  2 ❙  2 ❙  0 ❙  0 ❙  6
+                Blithering Badgers             ❙  2 ❙  0 ❙  0 ❙  2 ❙  0
             }
             express tally {
                 Allegoric Alaskans;Blithering Badgers;win
@@ -70,9 +72,9 @@ describe "Tournament" [
     it.skip "There can be more than one winner" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3
-                Blithering Badgers             |  2 |  1 |  0 |  1 |  3
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  2 ❙  1 ❙  0 ❙  1 ❙  3
+                Blithering Badgers             ❙  2 ❙  1 ❙  0 ❙  1 ❙  3
             }
             express tally {
                 Allegoric Alaskans;Blithering Badgers;loss
@@ -84,10 +86,10 @@ describe "Tournament" [
     it.skip "There can be more than two teams" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
-                Blithering Badgers             |  2 |  1 |  0 |  1 |  3
-                Courageous Californians        |  2 |  0 |  0 |  2 |  0
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  2 ❙  2 ❙  0 ❙  0 ❙  6
+                Blithering Badgers             ❙  2 ❙  1 ❙  0 ❙  1 ❙  3
+                Courageous Californians        ❙  2 ❙  0 ❙  0 ❙  2 ❙  0
             }
             express tally {
                 Allegoric Alaskans;Blithering Badgers;win
@@ -100,11 +102,11 @@ describe "Tournament" [
     it.skip "typical input" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
-                Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
-                Blithering Badgers             |  3 |  1 |  0 |  2 |  3
-                Courageous Californians        |  3 |  0 |  1 |  2 |  1
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Devastating Donkeys            ❙  3 ❙  2 ❙  1 ❙  0 ❙  7
+                Allegoric Alaskans             ❙  3 ❙  2 ❙  0 ❙  1 ❙  6
+                Blithering Badgers             ❙  3 ❙  1 ❙  0 ❙  2 ❙  3
+                Courageous Californians        ❙  3 ❙  0 ❙  1 ❙  2 ❙  1
             }
             express tally {
                 Allegoric Alaskans;Blithering Badgers;win
@@ -120,11 +122,11 @@ describe "Tournament" [
     it.skip "incomplete competition (not all pairs have played)" [ 
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
-                Blithering Badgers             |  2 |  1 |  1 |  0 |  4
-                Courageous Californians        |  2 |  0 |  1 |  1 |  1
-                Devastating Donkeys            |  1 |  0 |  0 |  1 |  0
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  3 ❙  2 ❙  0 ❙  1 ❙  6
+                Blithering Badgers             ❙  2 ❙  1 ❙  1 ❙  0 ❙  4
+                Courageous Californians        ❙  2 ❙  0 ❙  1 ❙  1 ❙  1
+                Devastating Donkeys            ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
             }
             express tally {
                 Allegoric Alaskans;Blithering Badgers;loss
@@ -138,11 +140,11 @@ describe "Tournament" [
     it.skip "ties broken alphabetically" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
-                Courageous Californians        |  3 |  2 |  1 |  0 |  7
-                Blithering Badgers             |  3 |  0 |  1 |  2 |  1
-                Devastating Donkeys            |  3 |  0 |  1 |  2 |  1
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Allegoric Alaskans             ❙  3 ❙  2 ❙  1 ❙  0 ❙  7
+                Courageous Californians        ❙  3 ❙  2 ❙  1 ❙  0 ❙  7
+                Blithering Badgers             ❙  3 ❙  0 ❙  1 ❙  2 ❙  1
+                Devastating Donkeys            ❙  3 ❙  0 ❙  1 ❙  2 ❙  1
             }
             express tally {
                 Courageous Californians;Devastating Donkeys;win
@@ -158,9 +160,9 @@ describe "Tournament" [
     it.skip "ensure points sorted numerically" [
         expects.be:'equal? @[
             express {
-                Team                           | MP |  W |  D |  L |  P
-                Devastating Donkeys            |  5 |  4 |  0 |  1 | 12
-                Blithering Badgers             |  5 |  1 |  0 |  4 |  3
+                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Devastating Donkeys            ❙  5 ❙  4 ❙  0 ❙  1 ❙ 12
+                Blithering Badgers             ❙  5 ❙  1 ❙  0 ❙  4 ❙  3
             }
             express tally {
                 Devastating Donkeys;Blithering Badgers;win

--- a/exercises/practice/transpose/.meta/src/example.art
+++ b/exercises/practice/transpose/.meta/src/example.art
@@ -1,7 +1,7 @@
 transpose: function [data][
     if empty? data -> return ""
     
-    lines: split.lines lines
+    lines: split.lines data
     maxLength: max map lines 'line -> size line
     paddedLines: map lines 'line -> pad.right line maxLength
 

--- a/exercises/practice/transpose/tests/test-transpose.art
+++ b/exercises/practice/transpose/tests/test-transpose.art
@@ -1,51 +1,53 @@
 import.version:2.0.1 {unitt}!
 import {src/transpose}!
 
-suite "Transpose" [
-    test "empty string" [
-        lines: ""
-        result: transpose lines
-        expected: ""
-        assert -> expected = result
+describe "Transpose" [
+    it "empty string" [
+        expects.be:'equal? @[
+            express ""
+            express transpose ""
+        ]
     ]
 
-    test.skip "two characters in a row" [
-        lines: "A1"
-        result: transpose lines
+    it.skip "two characters in a row" [
         expected: join.with:"\n" [
             "A"
             "1"
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose "A1"
+        ]
     ]
 
-    test.skip "two characters in a column" [
+    it.skip "two characters in a column" [
         lines: join.with:"\n" [
             "A"
             "1"
         ]
-        result: transpose lines
-        expected: "A1"
-        assert -> expected = result
+        expects.be:'equal? @[
+            express "A1"
+            express transpose lines
+        ]
     ]
 
-    test.skip "simple" [
+    it.skip "simple" [
         lines: join.with:"\n" [
             "ABC"
             "123"
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "A1"
             "B2"
             "C3"
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 
-    test.skip "single line" [
-        lines: "Single line."
-        result: transpose lines
+    it.skip "single line" [
         expected: join.with:"\n" [
             "S"
             "i"
@@ -60,15 +62,17 @@ suite "Transpose" [
             "e"
             "."
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose "Single line."
+        ]
     ]
 
-    test.skip "first line longer than second line" [
+    it.skip "first line longer than second line" [
         lines: join.with:"\n" [
             "The fourth line."
             "The fifth line."
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "TT"
             "hh"
@@ -87,15 +91,17 @@ suite "Transpose" [
             "e."
             "."
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 
-    test.skip "second line longer than first line" [
+    it.skip "second line longer than first line" [
         lines: join.with:"\n" [
             "The first line."
             "The second line."
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "TT"
             "hh"
@@ -114,17 +120,19 @@ suite "Transpose" [
             ".e"
             " ."
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 
-    test.skip "mixed line length" [
+    it.skip "mixed line length" [
         lines: join.with:"\n" [
             "The longest line."
             "A long line."
             "A longer line."
             "A line."
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "TAAA"
             "h   "
@@ -144,10 +152,13 @@ suite "Transpose" [
             "e"
             "."
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 
-    test.skip "square" [
+    it.skip "square" [
         lines: join.with:"\n" [
             "HEART"
             "EMBER"
@@ -155,7 +166,6 @@ suite "Transpose" [
             "RESIN"
             "TREND"
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "HEART"
             "EMBER"
@@ -163,17 +173,19 @@ suite "Transpose" [
             "RESIN"
             "TREND"
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 
-    test.skip "rectangle" [
+    it.skip "rectangle" [
         lines: join.with:"\n" [
             "FRACTURE"
             "OUTLINED"
             "BLOOMING"
             "SEPTETTE"
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "FOBS"
             "RULE"
@@ -184,10 +196,13 @@ suite "Transpose" [
             "RENT"
             "EDGE"
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 
-    test.skip "triangle" [
+    it.skip "triangle" [
         lines: join.with:"\n" [
             "T"
             "EE"
@@ -196,7 +211,6 @@ suite "Transpose" [
             "EEEEE"
             "RRRRRR"
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "TEASER"
             " EASER"
@@ -205,10 +219,13 @@ suite "Transpose" [
             "    ER"
             "     R"
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 
-    test.skip "jagged triangle" [
+    it.skip "jagged triangle" [
         lines: join.with:"\n" [
             "11"
             "2"
@@ -217,7 +234,6 @@ suite "Transpose" [
             "555555"
             "66666"
         ]
-        result: transpose lines
         expected: join.with:"\n" [
             "123456"
             "1 3456"
@@ -226,6 +242,9 @@ suite "Transpose" [
             "    56"
             "    5"
         ]
-        assert -> expected = result
+        expects.be:'equal? @[
+            express expected
+            express transpose lines
+        ]
     ]
 ]

--- a/exercises/practice/triangle/tests/test-triangle.art
+++ b/exercises/practice/triangle/tests/test-triangle.art
@@ -1,109 +1,94 @@
 import.version:2.0.1 {unitt}!
 import {src/triangle}!
 
-suite "Triangle" [
-    test "invalid: 0 0 0" [
-        result: equilateral? 0 0 0
-        assert -> false = result
+describe "Triangle" [
+    describe "Triangle - Equilateral" [
+        it "invalid: 0 0 0" [
+            expects.be:'false? @[equilateral? 0 0 0]
+        ]
+
+        it.skip "equilateral with floating point" [
+            expects.be:'true? @[equilateral? 0.5 0.5 0.5]
+        ]
+
+        it.skip "equilateral 2 2 2" [
+            expects.be:'true? @[equilateral? 2 2 2]
+        ]
+
+        it.skip "isosceles is not equilateral" [
+            expects.be:'false? @[equilateral? 2 3 2]
+        ]
+
+        it.skip "scalene is not equilateral" [
+            expects.be:'false? @[equilateral? 5 4 6]
+        ]
     ]
 
-    test.skip "equilateral with floating point" [
-        result: equilateral? 0.5 0.5 0.5
-        assert -> true = result
+    describe "Triangle - Isosceles" [
+        it.skip "isosceles with floating point" [
+            expects.be:'true? @[isosceles? 0.5 0.4 0.5]
+        ]
+
+        it.skip "(invalid) isosceles 1 1 3, 3 in last position" [
+            expects.be:'false? @[isosceles? 1 1 3]
+        ]
+
+        it.skip "(invalid) isosceles 1 3 1, 3 in middle position" [
+            expects.be:'false? @[isosceles? 1 3 1]
+        ]
+
+        it.skip "(invalid) isosceles 3 1 1, 3 in first position" [
+            expects.be:'false? @[isosceles? 3 1 1]
+        ]
+
+        it.skip "isosceles 2 2 3, 3 in last position" [
+            expects.be:'true? @[isosceles? 2 2 3]
+        ]
+
+        it.skip "isosceles 2 3 2, 3 in middle position" [
+            expects.be:'true? @[isosceles? 2 3 2]
+        ]
+
+        it.skip "isosceles 3 2 2, 3 in first position" [
+            expects.be:'true? @[isosceles? 3 2 2]
+        ]
+
+        it.skip "is scalene and isosceles?" [
+            expects.be:'false? @[isosceles? 2 3 4]
+        ]
+
+        it.skip "equilateral is also isosceles" [
+            expects.be:'true? @[isosceles? 4 4 4]
+        ]
     ]
 
-    test.skip "equilateral 2 2 2" [
-        result: equilateral? 2 2 2
-        assert -> true = result
-    ]
+    describe "Triangle - Scalene" [
+        it.skip "scalene with floating point" [
+            expects.be:'true? @[scalene? 0.5 0.4 0.6]
+        ]
 
-    test.skip "isosceles is not equilateral" [
-        result: equilateral? 2 3 2
-        assert -> false = result
-    ]
+        it.skip "isosceles is not scalene" [
+            expects.be:'false? @[scalene? 4 4 3]
+        ]
 
-    test.skip "scalene is not equilateral" [
-        result: equilateral? 5 4 6
-        assert -> false = result
-    ]
+        it.skip "equilateral is not scalene" [
+            expects.be:'false? @[scalene? 4 4 4]
+        ]
 
-    test.skip "isosceles with floating point" [
-        result: isosceles? 0.5 0.4 0.5
-        assert -> true = result
-    ]
+        it.skip "scalene 5 4 6" [
+            expects.be:'true? @[scalene? 5 4 6]
+        ]
 
-    test.skip "(invalid) isosceles 1 1 3, 3 in last position" [
-        result: isosceles? 1 1 3
-        assert -> false = result
-    ]
+        it.skip "triangle inequality rule violation" [
+            expects.be:'false? @[scalene? 7 3 2]
+        ]
 
-    test.skip "(invalid) isosceles 1 3 1, 3 in middle position" [
-        result: isosceles? 1 3 1
-        assert -> false = result
-    ]
+        it.skip "broken triangle #1" [
+            expects.be:'false? @[scalene? 0 3 3]
+        ]
 
-    test.skip "(invalid) isosceles 3 1 1, 3 in first position" [
-        result: isosceles? 3 1 1
-        assert -> false = result
-    ]
-
-    test.skip "isosceles 2 2 3, 3 in last position" [
-        result: isosceles? 2 2 3
-        assert -> true = result
-    ]
-
-    test.skip "isosceles 2 3 2, 3 in middle position" [
-        result: isosceles? 2 3 2
-        assert -> true = result
-    ]
-
-    test.skip "isosceles 3 2 2, 3 in first position" [
-        result: isosceles? 3 2 2
-        assert -> true = result
-    ]
-
-    test.skip "is scalene and isosceles?" [
-        result: isosceles? 2 3 4
-        assert -> false = result
-    ]
-
-    test.skip "equilateral is also isosceles" [
-        result: isosceles? 4 4 4
-        assert -> true = result
-    ]
-
-    test.skip "scalene with floating point" [
-        result: scalene? 0.5 0.4 0.6
-        assert -> true = result
-    ]
-
-    test.skip "isosceles is not scalene" [
-        result: scalene? 4 4 3
-        assert -> false = result
-    ]
-
-    test.skip "equilateral is not scalene" [
-        result: scalene? 4 4 4
-        assert -> false = result
-    ]
-
-    test.skip "scalene 5 4 6" [
-        result: scalene? 5 4 6
-        assert -> true = result
-    ]
-
-    test.skip "triangle inequality rule violation" [
-        result: scalene? 7 3 2
-        assert -> false = result
-    ]
-
-    test.skip "broken triangle #1" [
-        result: scalene? 0 3 3
-        assert -> false = result
-    ]
-
-    test.skip "broken triangle #2" [
-        result: scalene? 0 3 0
-        assert -> false = result
+        it.skip "broken triangle #2" [
+            expects.be:'false? @[scalene? 0 3 0]
+        ]
     ]
 ]

--- a/exercises/practice/twelve-days/tests/test-twelve-days.art
+++ b/exercises/practice/twelve-days/tests/test-twelve-days.art
@@ -2,119 +2,134 @@ import.version:2.0.1 {unitt}!
 import {src/twelve-days}!
 
 
-suite "Twelve Days" [
-    suite "verse" [
-        test "first day a partridge in a pear tree" [
-            results: recite 1 1
-            expected: "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
-            assert -> expected = results
+describe "Twelve Days" [
+    describe "Twelve Days - Verse" [
+        it "first day a partridge in a pear tree" [
+            expects.be:'equal? @[
+                express "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
+                express recite 1 1
+            ]
         ]
 
-        test.skip "second day two turtle doves" [
-            results: recite 2 2
-            expected: "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "second day two turtle doves" [
+            expects.be:'equal? @[
+                express "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 2 2
+            ]
         ]
 
-        test.skip "third day three french hens" [
-            results: recite 3 3
-            expected: "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "third day three french hens" [
+            expects.be:'equal? @[
+                express "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 3 3
+            ]
         ]
 
-        test.skip "fourth day four calling birds" [
-            results: recite 4 4
-            expected: "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "fourth day four calling birds" [
+            expects.be:'equal? @[
+                express "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 4 4
+            ]
         ]
 
-        test.skip "fifth day five gold rings" [
-            results: recite 5 5
-            expected: "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "fifth day five gold rings" [
+            expects.be:'equal? @[
+                express "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 5 5
+            ]
         ]
 
-        test.skip "sixth day six geese-a-laying" [
-            results: recite 6 6
-            expected: "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "sixth day six geese-a-laying" [
+            expects.be:'equal? @[
+                express "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 6 6
+            ]
         ]
 
-        test.skip "seventh day seven swans-a-swimming" [
-            results: recite 7 7
-            expected: "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "seventh day seven swans-a-swimming" [
+            expects.be:'equal? @[
+                express "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 7 7
+            ]
         ]
 
-        test.skip "eighth day eight maids-a-milking" [
-            results: recite 8 8
-            expected: "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "eighth day eight maids-a-milking" [
+            expects.be:'equal? @[
+                express "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 8 8
+            ]
         ]
 
-        test.skip "ninth day nine ladies dancing" [
-            results: recite 9 9
-            expected: "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "ninth day nine ladies dancing" [
+            expects.be:'equal? @[
+                express "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 9 9
+            ]
         ]
 
-        test.skip "tenth day ten lords-a-leaping" [
-            results: recite 10 10
-            expected: "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "tenth day ten lords-a-leaping" [
+            expects.be:'equal? @[
+                express "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 10 10
+            ]
         ]
 
-        test.skip "eleventh day eleven pipers piping" [
-            results: recite 11 11
-            expected: "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "eleventh day eleven pipers piping" [
+            expects.be:'equal? @[
+                express "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 11 11
+            ]
         ]
 
-        test.skip "twelfth day twelve drummers drumming" [
-            results: recite 12 12
-            expected: "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-            assert -> expected = results
+        it.skip "twelfth day twelve drummers drumming" [
+            expects.be:'equal? @[
+                express "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                express recite 12 12
+            ]
         ]
     ]
 
-    suite "lyrics" [
-        test.skip "recites first three verses of the song" [
-            results: recite 1 3
-            expected: join.with:"\n" [
-                "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
-                "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+    describe "Twelve Days - Lyrics" [
+        it.skip "recites first three verses of the song" [
+            expects.be:'equal? @[
+                express join.with:"\n" [
+                    "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
+                    "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                ]
+                express recite 1 3
             ]
-            assert -> expected = results
         ]
 
-        test.skip "recites three verses from the middle of the song" [
-            results: recite 4 6
-            expected: join.with:"\n" [
-                "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+        it.skip "recites three verses from the middle of the song" [
+            expects.be:'equal? @[
+                express join.with:"\n" [
+                    "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                ]
+                express recite 4 6
             ]
-            assert -> expected = results
         ]
 
-        test.skip "recites the whole song" [
-            results: recite 1 12
-            expected: join.with:"\n" [
-                "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
-                "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
-                "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+        it.skip "recites the whole song" [
+            expects.be:'equal? @[
+                express join.with:"\n" [
+                    "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
+                    "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                    "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
+                ]
+                express recite 1 12
             ]
-            assert -> expected = results
         ]
     ]
 ]

--- a/exercises/practice/two-bucket/tests/test-two-bucket.art
+++ b/exercises/practice/two-bucket/tests/test-two-bucket.art
@@ -1,110 +1,117 @@
 import.version:2.0.1 {unitt}!
 import {src/two-bucket}!
 
-suite "Two Bucket" [
-
-    test "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one" [
+describe "Two Bucket" [
+    it "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one" [
         result: measure #[
             bucketOne: 3
             bucketTwo: 5
             goal: 1
             startBucket: "one"
         ]
-        assert -> result\moves = 4
-        assert -> result\goalBucket = "one"
-        assert -> result\otherBucket = 5
+        expects.be:'equal? @[
+            express [4 "one" 5]
+            express @[result\moves result\goalBucket result\otherBucket]
+        ]
     ]
 
-    test.skip "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two" [
-
+    it.skip "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two" [
         result: measure #[
             bucketOne: 3
             bucketTwo: 5
             goal: 1
             startBucket: "two"
         ]
-        assert -> result\moves = 8
-        assert -> result\goalBucket = "two"
-        assert -> result\otherBucket = 3
+        expects.be:'equal? @[
+            express [8 "two" 3]
+            express @[result\moves result\goalBucket result\otherBucket]
+        ]
     ]
 
-    test.skip "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one" [
+    it.skip "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one" [
         result: measure #[
             bucketOne: 7
             bucketTwo: 11
             goal: 2
             startBucket: "one"
         ]
-        assert -> result\moves = 14
-        assert -> result\goalBucket = "one"
-        assert -> result\otherBucket = 11
+        expects.be:'equal? @[
+            express [14 "one" 11]
+            express @[result\moves result\goalBucket result\otherBucket]
+        ]
     ]
 
-    test.skip "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two" [
+    it.skip "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two" [
         result: measure #[
             bucketOne: 7
             bucketTwo: 11
             goal: 2
             startBucket: "two"
         ]
-        assert -> result\moves = 18
-        assert -> result\goalBucket = "two"
-        assert -> result\otherBucket = 7
+        expects.be:'equal? @[
+            express [18 "two" 7]
+            express @[result\moves result\goalBucket result\otherBucket]
+        ]
     ]
 
-    test.skip "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two" [
+    it.skip "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two" [
         result: measure #[
             bucketOne: 1
             bucketTwo: 3
             goal: 3
             startBucket: "two"
         ]
-        assert -> result\moves = 1
-        assert -> result\goalBucket = "two"
-        assert -> result\otherBucket = 0
+        expects.be:'equal? @[
+            express [1 "two" 0]
+            express @[result\moves result\goalBucket result\otherBucket]
+        ]
     ]
 
-    test.skip "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two" [
+    it.skip "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two" [
         result: measure #[
             bucketOne: 2
             bucketTwo: 3
             goal: 3
             startBucket: "one"
         ]
-        assert -> result\moves = 2
-        assert -> result\goalBucket = "two"
-        assert -> result\otherBucket = 2
-    ]
-
-    test.skip "Not possible to reach the goal" [
-        result: measure #[
-            bucketOne: 6
-            bucketTwo: 15
-            goal: 5
-            startBucket: "one"
+        expects.be:'equal? @[
+            express [2 "two" 2]
+            express @[result\moves result\goalBucket result\otherBucket]
         ]
-        assert -> null? result
     ]
 
-    test.skip "With the same buckets but a different goal, then it is possible" [
+    it.skip "Not possible to reach the goal" [
+        expects.be:'null? @[
+            measure #[
+                bucketOne: 6
+                bucketTwo: 15
+                goal: 5
+                startBucket: "one"
+            ]
+        ]
+    ]
+
+    it.skip "With the same buckets but a different goal, then it is possible" [
         result: measure #[
             bucketOne: 6
             bucketTwo: 15
             goal: 9
             startBucket: "one"
         ]
-        assert -> result\moves = 10
-        assert -> result\goalBucket = "two"
-        assert -> result\otherBucket = 0
+        expects.be:'equal? @[
+            express [10 "two" 0]
+            express @[result\moves result\goalBucket result\otherBucket]
+        ]
     ]
 
-    test.skip "Goal larger than both buckets is impossible" [
-        result: measure #[
-            bucketOne: 5
-            bucketTwo: 7
-            goal: 8
-            startBucket: "one"
+    it.skip "Goal larger than both buckets is impossible" [
+        expects.be:'null? @[
+            measure #[
+                bucketOne: 5
+                bucketTwo: 7
+                goal: 8
+                startBucket: "one"
+            ]
         ]
-        assert -> null? result
     ]
 ]

--- a/exercises/practice/two-fer/tests/test-two-fer.art
+++ b/exercises/practice/two-fer/tests/test-two-fer.art
@@ -1,19 +1,25 @@
 import.version:2.0.1 {unitt}!
 import {src/two-fer}!
 
-suite "Two Fer" [
-    test "no name given" [
-        result: twoFer ""
-        assert -> "One for you, one for me." = result
+describe "Two Fer" [
+    it "no name given" [
+        expects.be:'equal? @[
+            express "One for you, one for me."
+            express twoFer ""
+        ]
     ]
 
-    test.skip "a name given" [
-        result: twoFer "Alice"
-        assert -> "One for Alice, one for me." = result
+    it.skip "a name given" [
+        expects.be:'equal? @[
+            express "One for Alice, one for me."
+            express twoFer "Alice"
+        ]
     ]
     
-    test.skip "another name given" [
-        result: twoFer "Bob"
-        assert -> "One for Bob, one for me." = result
+    it.skip "another name given" [
+        expects.be:'equal? @[
+            express "One for Bob, one for me."
+            express twoFer "Bob"
+        ]
     ]
 ]

--- a/exercises/practice/word-count/tests/test-word-count.art
+++ b/exercises/practice/word-count/tests/test-word-count.art
@@ -1,102 +1,84 @@
 import.version:2.0.1 {unitt}!
 import {src/word-count}!
 
-suite "Word Count" [
-  test "count one word" [
-    sentence: "word"
-    result: countWords sentence
-    expected: #["word": 1]
-    assert -> expected = result
-  ]
+describe "Word Count" [
+    it "count one word" [
+        expects.be:'equal? @[#["word": 1] countWords "word"]
+    ]
 
-  test.skip "count one of each word" [
-    sentence: "one of each"
-    result: countWords sentence
-    expected: #["one": 1 "of": 1 "each": 1]
-    assert -> expected = result
-  ]
+    it.skip "count one of each word" [
+        expects.be:'equal? @[#["one": 1 "of": 1 "each": 1] countWords "one of each"]
+    ]
 
-  test.skip "multiple occurrences of a word" [
-    sentence: "one fish two fish red fish blue fish"
-    result: countWords sentence
-    expected: #["one": 1 "fish": 4 "two": 1 "red": 1 "blue": 1]
-    assert -> expected = result
-  ]
+    it.skip "multiple occurrences of a word" [
+        expects.be:'equal? @[
+            #["one": 1 "fish": 4 "two": 1 "red": 1 "blue": 1]
+            countWords "one fish two fish red fish blue fish"
+        ]
+    ]
 
-  test.skip "handles cramped lists" [
-    sentence: "one,two,three"
-    result: countWords sentence
-    expected: #["one": 1 "two": 1 "three": 1]
-    assert -> expected = result
-  ]
+    it.skip "handles cramped lists" [
+        expects.be:'equal? @[#["one": 1 "two": 1 "three": 1] countWords "one,two,three"]
+    ]
 
-  test.skip "handles expanded lists" [
-    sentence: "one,\ntwo,\nthree"
-    result: countWords sentence
-    expected: #["one": 1 "two": 1 "three": 1]
-    assert -> expected = result
-  ]
+    it.skip "handles expanded lists" [
+        expects.be:'equal? @[
+            #["one": 1 "two": 1 "three": 1]
+            countWords "one,\ntwo,\nthree"
+        ]
+    ]
 
-  test.skip "ignore punctuation" [
-    sentence: "car: carpet as java: javascript!!&@$%^&"
-    result: countWords sentence
-    expected: #["car": 1 "carpet": 1 "as": 1 "java": 1 "javascript": 1]
-    assert -> expected = result
-  ]
+    it.skip "ignore punctuation" [
+        expects.be:'equal? @[
+            #["car": 1 "carpet": 1 "as": 1 "java": 1 "javascript": 1]
+            countWords "car: carpet as java: javascript!!&@$%^&"
+        ]
+    ]
 
-  test.skip "include numbers" [
-    sentence: "testing, 1, 2 testing"
-    result: countWords sentence
-    expected: #["testing": 2 "1": 1 "2": 1]
-    assert -> expected = result
-  ]
+    it.skip "include numbers" [
+        expects.be:'equal? @[#["iting": 2 "1": 1 "2": 1] countWords "iting, 1, 2 iting"]
+    ]
 
-  test.skip "normalize case" [
-    sentence: "go Go GO Stop stop"
-    result: countWords sentence
-    expected: #["go": 3 "stop": 2]
-    assert -> expected = result
-  ]
+    it.skip "normalize case" [
+        expects.be:'equal? @[#["go": 3 "stop": 2] countWords "go Go GO Stop stop"]
+    ]
 
-  test.skip "with apostrophes" [
-    sentence: "'First: don't laugh. Then: don't cry. You're getting it.'"
-    result: countWords sentence
-    expected: #["first": 1 "don't": 2 "laugh": 1 "then": 1 "cry": 1 "you're": 1 "getting": 1 "it": 1]
-    assert -> expected = result
-  ]
+    it.skip "with apostrophes" [
+        expects.be:'equal? @[
+            #["first": 1 "don't": 2 "laugh": 1 "then": 1 "cry": 1 "you're": 1 "getting": 1 "it": 1]
+            countWords "'First: don't laugh. Then: don't cry. You're getting it.'"
+        ]
+    ]
 
-  test.skip "with quotations" [
-    sentence: "Joe can't tell between 'large' and large."
-    result: countWords sentence
-    expected: #["joe": 1 "can't": 1 "tell": 1 "between": 1 "large": 2 "and": 1]
-    assert -> expected = result
-  ]
+    it.skip "with quotations" [
+        expects.be:'equal? @[
+            #["joe": 1 "can't": 1 "tell": 1 "between": 1 "large": 2 "and": 1]
+            countWords "Joe can't tell between 'large' and large."
+        ]
+    ]
 
-  test.skip "substrings from the beginning" [
-    sentence: "Joe can't tell between app, apple and a."
-    result: countWords sentence
-    expected: #["joe": 1 "can't": 1 "tell": 1 "between": 1 "app": 1 "apple": 1 "and": 1 "a": 1]
-    assert -> expected = result
-  ]
+    it.skip "substrings from the beginning" [
+        expects.be:'equal? @[
+            #["joe": 1 "can't": 1 "tell": 1 "between": 1 "app": 1 "apple": 1 "and": 1 "a": 1]
+            countWords "Joe can't tell between app, apple and a."
+        ]
+    ]
 
-  test.skip "multiple spaces not detected as a word" [
-    sentence: " multiple   whitespaces"
-    result: countWords sentence
-    expected: #["multiple": 1 "whitespaces": 1]
-    assert -> expected = result
-  ]
+    it.skip "multiple spaces not detected as a word" [
+        expects.be:'equal? @[
+            #["multiple": 1 "whitespaces": 1]
+            countWords " multiple   whitespaces"
+        ]
+    ]
 
-  test.skip "alternating word separators not detected as a word" [
-    sentence: ",\n,one,\n ,two \n 'three'"
-    result: countWords sentence
-    expected: #["one": 1 "two": 1 "three": 1]
-    assert -> expected = result
-  ]
+    it.skip "alternating word separators not detected as a word" [
+        expects.be:'equal? @[
+            #["one": 1 "two": 1 "three": 1]
+            countWords ",\n,one,\n ,two \n 'three'"
+        ]
+    ]
 
-  test.skip "quotation for word with apostrophe" [
-    sentence: "can, can't, 'can't'"
-    result: countWords sentence
-    expected: #["can": 1 "can't": 2]
-    assert -> expected = result
-  ]
+    it.skip "quotation for word with apostrophe" [
+        expects.be:'equal? @[#["can": 1 "can't": 2] countWords "can, can't, 'can't'"]
+    ]
 ]

--- a/exercises/practice/yacht/tests/test-yacht.art
+++ b/exercises/practice/yacht/tests/test-yacht.art
@@ -1,149 +1,120 @@
 import.version:2.0.1 {unitt}!
 import {src/yacht}!
 
-suite "Yacht" [
-    test.skip "Yacht" [
-        result: yacht [5, 5, 5, 5, 5] "yacht" 
-        assert -> 50 = result
+describe "Yacht" [
+    it "Yacht" [
+        expects.be:'equal? @[50 yacht [5 5 5 5 5] "yacht"]
     ]
 
-    test.skip "Not Yacht" [
-        result: yacht [1, 3, 3, 2, 5] "yacht" 
-        assert -> 0 = result
+    it.skip "Not Yacht" [
+        expects.be:'equal? @[0 yacht [1 3 3 2 5] "yacht"]
     ]
 
-    test.skip "Ones" [
-        result: yacht [1, 1, 1, 3, 5] "ones" 
-        assert -> 3 = result
+    it.skip "Ones" [
+        expects.be:'equal? @[3 yacht [1 1 1 3 5] "ones"]
     ]
 
-    test.skip "Ones, out of order" [
-        result: yacht [3, 1, 1, 5, 1] "ones" 
-        assert -> 3 = result
+    it.skip "Ones out of order" [
+        expects.be:'equal? @[3 yacht [3 1 1 5 1] "ones"]
     ]
 
-    test.skip "No ones" [
-        result: yacht [4, 3, 6, 5, 5] "ones" 
-        assert -> 0 = result
+    it.skip "No ones" [
+        expects.be:'equal? @[0 yacht [4 3 6 5 5] "ones"]
     ]
 
-    test.skip "Twos" [
-        result: yacht [2, 3, 4, 5, 6] "twos" 
-        assert -> 2 = result
+    it.skip "Twos" [
+        expects.be:'equal? @[2 yacht [2 3 4 5 6] "twos"]
     ]
 
-    test.skip "Yacht counted as threes" [
-        result: yacht [3, 3, 3, 3, 3] "threes" 
-        assert -> 15 = result
+    it.skip "Yacht counted as threes" [
+        expects.be:'equal? @[15 yacht [3 3 3 3 3] "threes"]
     ]
 
-    test.skip "Fours" [
-        result: yacht [1, 4, 1, 4, 1] "fours" 
-        assert -> 8 = result
+    it.skip "Fours" [
+        expects.be:'equal? @[8 yacht [1 4 1 4 1] "fours"]
     ]
 
-    test.skip "Yacht of 3s counted as fives" [
-        result: yacht [3, 3, 3, 3, 3] "fives" 
-        assert -> 0 = result
+    it.skip "Yacht of 3s counted as fives" [
+        expects.be:'equal? @[0 yacht [3 3 3 3 3] "fives"]
     ]
 
-    test.skip "Fives" [
-        result: yacht [1, 5, 3, 5, 3] "fives" 
-        assert -> 10 = result
+    it.skip "Fives" [
+        expects.be:'equal? @[10 yacht [1 5 3 5 3] "fives"]
     ]
 
-    test.skip "Sixes" [
-        result: yacht [2, 3, 4, 5, 6] "sixes" 
-        assert -> 6 = result
+    it.skip "Sixes" [
+        expects.be:'equal? @[6 yacht [2 3 4 5 6] "sixes"]
     ]
 
-    test.skip "Four of a Kind" [
-        result: yacht [6, 6, 4, 6, 6] "four of a kind" 
-        assert -> 24 = result
+    it.skip "Four of a Kind" [
+        expects.be:'equal? @[24 yacht [6 6 4 6 6] "four of a kind"]
     ]
 
-    test.skip "Yacht can be scored as Four of a Kind" [
-        result: yacht [3, 3, 3, 3, 3] "four of a kind" 
-        assert -> 12 = result
+    it.skip "Yacht can be scored as Four of a Kind" [
+        expects.be:'equal? @[12 yacht [3 3 3 3 3] "four of a kind"]
     ]
 
-    test.skip "Full house is not Four of a Kind" [
-        result: yacht [3, 3, 3, 5, 5] "four of a kind" 
-        assert -> 0 = result
+    it.skip "Full house is not Four of a Kind" [
+        expects.be:'equal? @[0 yacht [3 3 3 5 5] "four of a kind"]
     ]
 
-    test.skip "Little Straight" [
-        result: yacht [3, 5, 4, 1, 2] "little straight" 
-        assert -> 30 = result
+    it.skip "Little Straight" [
+        expects.be:'equal? @[30 yacht [3 5 4 1 2] "little straight"]
     ]
 
-    test.skip "Little Straight as Big Straight" [
-        result: yacht [1, 2, 3, 4, 5] "big straight" 
-        assert -> 0 = result
+    it.skip "Little Straight as Big Straight" [
+        expects.be:'equal? @[0 yacht [1 2 3 4 5] "big straight"]
     ]
 
-    test.skip "Four in order but not a little straight" [
-        result: yacht [1, 1, 2, 3, 4] "little straight" 
-        assert -> 0 = result
+    it.skip "Four in order but not a little straight" [
+        expects.be:'equal? @[0 yacht [1 1 2 3 4] "little straight"]
     ]
 
-    test.skip "No pairs but not a little straight" [
-        result: yacht [1, 2, 3, 4, 6] "little straight" 
-        assert -> 0 = result
+    it.skip "No pairs but not a little straight" [
+        expects.be:'equal? @[0 yacht [1 2 3 4 6] "little straight"]
     ]
 
-    test.skip "Minimum is 1, maximum is 5, but not a little straight" [
-        result: yacht [1, 1, 3, 4, 5] "little straight" 
-        assert -> 0 = result
+    it.skip "Minimum is 1 maximum is 5 but not a little straight" [
+        expects.be:'equal? @[0 yacht [1 1 3 4 5] "little straight"]
     ]
 
-    test.skip "Big Straight" [
-        result: yacht [4, 6, 2, 5, 3] "big straight" 
-        assert -> 30 = result
+    it.skip "Big Straight" [
+        expects.be:'equal? @[30 yacht [4 6 2 5 3] "big straight"]
     ]
 
-    test.skip "Big Straight as little straight" [
-        result: yacht [6, 5, 4, 3, 2] "little straight" 
-        assert -> 0 = result
+    it.skip "Big Straight as little straight" [
+        expects.be:'equal? @[0 yacht [6 5 4 3 2] "little straight"]
     ]
 
-    test.skip "No pairs but not a big straight" [
-        result: yacht [6, 5, 4, 3, 1] "big straight" 
-        assert -> 0 = result
+    it.skip "No pairs but not a big straight" [
+        expects.be:'equal? @[0 yacht [6 5 4 3 1] "big straight"]
     ]
 
-    test.skip "Full house two small, three big" [
-        result: yacht [2, 2, 4, 4, 4] "full house" 
-        assert -> 16 = result
+    it.skip "Full house two small three big" [
+        expects.be:'equal? @[16 yacht [2 2 4 4 4] "full house"]
     ]
 
-    test.skip "Full house three small, two big" [
-        result: yacht [5, 3, 3, 5, 3] "full house" 
-        assert -> 19 = result
+    it.skip "Full house three small two big" [
+        expects.be:'equal? @[19 yacht [5 3 3 5 3] "full house"]
     ]
 
-    test.skip "Two pair is not a full house" [
-        result: yacht [2, 2, 4, 4, 5] "full house" 
-        assert -> 0 = result
+    it.skip "Two pair is not a full house" [
+        expects.be:'equal? @[0 yacht [2 2 4 4 5] "full house"]
     ]
 
-    test.skip "Four of a kind is not a full house" [
-        result: yacht [1, 4, 4, 4, 4] "full house" 
-        assert -> 0 = result
+    it.skip "Four of a kind is not a full house" [
+        expects.be:'equal? @[0 yacht [1 4 4 4 4] "full house"]
     ]
 
-    test.skip "Yacht is not a full house" [
-        result: yacht [2, 2, 2, 2, 2] "full house" 
-        assert -> 0 = result
+    it.skip "Yacht is not a full house" [
+        expects.be:'equal? @[0 yacht [2 2 2 2 2] "full house"]
     ]
 
-    test.skip "Choice" [
-        result: yacht [3, 3, 5, 6, 6] "choice" 
-        assert -> 23 = result
+    it.skip "Choice" [
+        expects.be:'equal? @[23 yacht [3 3 5 6 6] "choice"]
     ]
 
-    test.skip "Yacht as choice" [
-        result: yacht [2, 2, 2, 2, 2] "choice" 
-        assert -> 10 = result
+    it.skip "Yacht as choice" [
+        expects.be:'equal? @[10 yacht [2 2 2 2 2] "choice"]
     ]
 ]


### PR DESCRIPTION
Do not merge until all exercise updates are drafted, additional golden tests are created, and testing docs are updated to reflect this RSpec-like testing API we're using going forward. This sets the stage for the unitt v2 to unitt v3 migration which will break a few things.

The exercises in this batch are below:

   tournament
   transpose
   triangle
   twelve-days
   two-bucket
   two-fer
   word-count
   yacht