### PR TITLE
Update invalidator files to prepare for a forced Unitt 3.x upgrade

### DIFF
--- a/exercises/practice/acronym/tester.art
+++ b/exercises/practice/acronym/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/allergies/tester.art
+++ b/exercises/practice/allergies/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/anagram/tester.art
+++ b/exercises/practice/anagram/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/armstrong-numbers/tester.art
+++ b/exercises/practice/armstrong-numbers/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/atbash-cipher/tester.art
+++ b/exercises/practice/atbash-cipher/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/binary-search/tester.art
+++ b/exercises/practice/binary-search/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/bob/tester.art
+++ b/exercises/practice/bob/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/bottle-song/tester.art
+++ b/exercises/practice/bottle-song/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/change/tester.art
+++ b/exercises/practice/change/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/clock/tester.art
+++ b/exercises/practice/clock/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/collatz-conjecture/tester.art
+++ b/exercises/practice/collatz-conjecture/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/darts/tester.art
+++ b/exercises/practice/darts/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/diamond/tester.art
+++ b/exercises/practice/diamond/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/difference-of-squares/tester.art
+++ b/exercises/practice/difference-of-squares/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/dnd-character/tester.art
+++ b/exercises/practice/dnd-character/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/eliuds-eggs/tester.art
+++ b/exercises/practice/eliuds-eggs/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/etl/tester.art
+++ b/exercises/practice/etl/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/flatten-array/tester.art
+++ b/exercises/practice/flatten-array/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/flower-field/tester.art
+++ b/exercises/practice/flower-field/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/food-chain/tester.art
+++ b/exercises/practice/food-chain/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/game-of-life/tester.art
+++ b/exercises/practice/game-of-life/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/gigasecond/tester.art
+++ b/exercises/practice/gigasecond/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/grains/tester.art
+++ b/exercises/practice/grains/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/hamming/tester.art
+++ b/exercises/practice/hamming/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/hello-world/tester.art
+++ b/exercises/practice/hello-world/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/high-scores/tester.art
+++ b/exercises/practice/high-scores/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/house/tester.art
+++ b/exercises/practice/house/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/isbn-verifier/tester.art
+++ b/exercises/practice/isbn-verifier/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/isogram/tester.art
+++ b/exercises/practice/isogram/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/kindergarten-garden/tester.art
+++ b/exercises/practice/kindergarten-garden/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/largest-series-product/tester.art
+++ b/exercises/practice/largest-series-product/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/leap/tester.art
+++ b/exercises/practice/leap/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/line-up/tester.art
+++ b/exercises/practice/line-up/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/luhn/tester.art
+++ b/exercises/practice/luhn/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/matching-brackets/tester.art
+++ b/exercises/practice/matching-brackets/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/matrix/tester.art
+++ b/exercises/practice/matrix/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/meetup/tester.art
+++ b/exercises/practice/meetup/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/nth-prime/tester.art
+++ b/exercises/practice/nth-prime/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/nucleotide-count/tester.art
+++ b/exercises/practice/nucleotide-count/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/pangram/tester.art
+++ b/exercises/practice/pangram/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/pascals-triangle/tester.art
+++ b/exercises/practice/pascals-triangle/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/perfect-numbers/tester.art
+++ b/exercises/practice/perfect-numbers/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/phone-number/tester.art
+++ b/exercises/practice/phone-number/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/prime-factors/tester.art
+++ b/exercises/practice/prime-factors/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/protein-translation/tester.art
+++ b/exercises/practice/protein-translation/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/proverb/tester.art
+++ b/exercises/practice/proverb/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/queen-attack/tester.art
+++ b/exercises/practice/queen-attack/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/raindrops/tester.art
+++ b/exercises/practice/raindrops/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/resistor-color-duo/tester.art
+++ b/exercises/practice/resistor-color-duo/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/resistor-color/tester.art
+++ b/exercises/practice/resistor-color/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/reverse-string/tester.art
+++ b/exercises/practice/reverse-string/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/rna-transcription/tester.art
+++ b/exercises/practice/rna-transcription/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/robot-simulator/tester.art
+++ b/exercises/practice/robot-simulator/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/roman-numerals/tester.art
+++ b/exercises/practice/roman-numerals/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/rotational-cipher/tester.art
+++ b/exercises/practice/rotational-cipher/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/run-length-encoding/tester.art
+++ b/exercises/practice/run-length-encoding/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/scrabble-score/tester.art
+++ b/exercises/practice/scrabble-score/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/secret-handshake/tester.art
+++ b/exercises/practice/secret-handshake/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/series/tester.art
+++ b/exercises/practice/series/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/sieve/tester.art
+++ b/exercises/practice/sieve/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/space-age/tester.art
+++ b/exercises/practice/space-age/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/square-root/tester.art
+++ b/exercises/practice/square-root/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/strain/tester.art
+++ b/exercises/practice/strain/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/sum-of-multiples/tester.art
+++ b/exercises/practice/sum-of-multiples/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/tournament/tester.art
+++ b/exercises/practice/tournament/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/transpose/tester.art
+++ b/exercises/practice/transpose/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/triangle/tester.art
+++ b/exercises/practice/triangle/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/twelve-days/tester.art
+++ b/exercises/practice/twelve-days/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/two-bucket/tester.art
+++ b/exercises/practice/two-bucket/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/two-fer/tester.art
+++ b/exercises/practice/two-fer/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/word-count/tester.art
+++ b/exercises/practice/word-count/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.

--- a/exercises/practice/yacht/tester.art
+++ b/exercises/practice/yacht/tester.art
@@ -5,3 +5,4 @@ exe: switch "windows" = sys\os
 fullpath: normalize ~"|path\home|/.arturo/packages/bin/|exe|"
 code: execute.code.directly ~"|fullpath|"
 panic.unstyled.code: code ""
+; A comment that once removed will be used to invalidate existing Unitt 2.x solutions so students can upgrade to the updated Unitt 3.x files.


### PR DESCRIPTION
In #208, the track was upgraded to Unitt 3.x but existing solutions weren't invalidated because I thought the no changes needed message would still show on the site that students need to update the exercises. Students with already started solutions are still pinned to the Unitt 2.x setup, but that's not compatible with the updated Unitt 3.x test runner. To fix this, I'm modifying all existing invalidator files as no important changes and then reverting the changes as important changes made.