### PR TITLE
Tournament: change the unicode medium vertical bars back to ascii vertical bars

### DIFF
--- a/exercises/practice/tournament/.docs/instructions.append.md
+++ b/exercises/practice/tournament/.docs/instructions.append.md
@@ -1,14 +1,5 @@
 # Instructions append
 
-## Use of the medium vertical bar
-
-~~~~exercism/caution
-In Arturo, `|` is the pipe operator for reversing the default right to left order of function calls.
-In v2 of the Unitt testing framework, there is currently an issue where instances of `|` are being unexpectedly evaluated inside strings.
-Therefore, we've replaced `|` (vertical bar) with `❙` (medium vertical bar) in the expected outputs.
-We're in the process of upgrading the track to Unitt v3 where this issue is fixed. Then we'll revert back to the expected `|` (vertical bar) delimiter.
-~~~~
-
 ## Some notes about Arturo strings
 
 You'll see some syntax in the tests that may be new to you: multiline strings enclosed in `{ braces }`.

--- a/exercises/practice/tournament/.meta/src/example.art
+++ b/exercises/practice/tournament/.meta/src/example.art
@@ -1,6 +1,6 @@
 tally: function [input][
     fmt: function [team][
-        join.with:" ❙ " @[
+        join.with:" | " @[
             (pad.right team\name 30)
             (pad to :string team\mp 2)
             (pad to :string team\w 2)

--- a/exercises/practice/tournament/tests/test-tournament.art
+++ b/exercises/practice/tournament/tests/test-tournament.art
@@ -5,7 +5,7 @@ describe "Tournament" [
     it "just the header if no input" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
+                Team                           | MP |  W |  D |  L |  P
             }
             tally ""
         ]
@@ -14,9 +14,9 @@ describe "Tournament" [
     it.skip "a win is three points, a loss is zero points" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  1 ❙  1 ❙  0 ❙  0 ❙  3
-                Blithering Badgers             ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+                Blithering Badgers             |  1 |  0 |  0 |  1 |  0
             }
             tally "Allegoric Alaskans;Blithering Badgers;win"
         ]
@@ -25,9 +25,9 @@ describe "Tournament" [
     it.skip "a win can also be expressed as a loss" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  1 ❙  1 ❙  0 ❙  0 ❙  3
-                Blithering Badgers             ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  1 |  1 |  0 |  0 |  3
+                Blithering Badgers             |  1 |  0 |  0 |  1 |  0
             }
             tally "Blithering Badgers;Allegoric Alaskans;loss"
         ]
@@ -36,9 +36,9 @@ describe "Tournament" [
     it.skip "a different team can win" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Blithering Badgers             ❙  1 ❙  1 ❙  0 ❙  0 ❙  3
-                Allegoric Alaskans             ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
+                Team                           | MP |  W |  D |  L |  P
+                Blithering Badgers             |  1 |  1 |  0 |  0 |  3
+                Allegoric Alaskans             |  1 |  0 |  0 |  1 |  0
             }
             tally "Blithering Badgers;Allegoric Alaskans;win"
         ]
@@ -47,9 +47,9 @@ describe "Tournament" [
     it.skip "a draw is one point each" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  1 ❙  0 ❙  1 ❙  0 ❙  1
-                Blithering Badgers             ❙  1 ❙  0 ❙  1 ❙  0 ❙  1
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  1 |  0 |  1 |  0 |  1
+                Blithering Badgers             |  1 |  0 |  1 |  0 |  1
             }
             tally "Allegoric Alaskans;Blithering Badgers;draw"
         ]
@@ -58,9 +58,9 @@ describe "Tournament" [
     it.skip "There can be more than one match" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  2 ❙  2 ❙  0 ❙  0 ❙  6
-                Blithering Badgers             ❙  2 ❙  0 ❙  0 ❙  2 ❙  0
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+                Blithering Badgers             |  2 |  0 |  0 |  2 |  0
             }
             tally {
                 Allegoric Alaskans;Blithering Badgers;win
@@ -72,9 +72,9 @@ describe "Tournament" [
     it.skip "There can be more than one winner" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  2 ❙  1 ❙  0 ❙  1 ❙  3
-                Blithering Badgers             ❙  2 ❙  1 ❙  0 ❙  1 ❙  3
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  2 |  1 |  0 |  1 |  3
+                Blithering Badgers             |  2 |  1 |  0 |  1 |  3
             }
             tally {
                 Allegoric Alaskans;Blithering Badgers;loss
@@ -86,10 +86,10 @@ describe "Tournament" [
     it.skip "There can be more than two teams" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  2 ❙  2 ❙  0 ❙  0 ❙  6
-                Blithering Badgers             ❙  2 ❙  1 ❙  0 ❙  1 ❙  3
-                Courageous Californians        ❙  2 ❙  0 ❙  0 ❙  2 ❙  0
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  2 |  2 |  0 |  0 |  6
+                Blithering Badgers             |  2 |  1 |  0 |  1 |  3
+                Courageous Californians        |  2 |  0 |  0 |  2 |  0
             }
             tally {
                 Allegoric Alaskans;Blithering Badgers;win
@@ -102,11 +102,11 @@ describe "Tournament" [
     it.skip "typical input" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Devastating Donkeys            ❙  3 ❙  2 ❙  1 ❙  0 ❙  7
-                Allegoric Alaskans             ❙  3 ❙  2 ❙  0 ❙  1 ❙  6
-                Blithering Badgers             ❙  3 ❙  1 ❙  0 ❙  2 ❙  3
-                Courageous Californians        ❙  3 ❙  0 ❙  1 ❙  2 ❙  1
+                Team                           | MP |  W |  D |  L |  P
+                Devastating Donkeys            |  3 |  2 |  1 |  0 |  7
+                Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+                Blithering Badgers             |  3 |  1 |  0 |  2 |  3
+                Courageous Californians        |  3 |  0 |  1 |  2 |  1
             }
             tally {
                 Allegoric Alaskans;Blithering Badgers;win
@@ -122,11 +122,11 @@ describe "Tournament" [
     it.skip "incomplete competition (not all pairs have played)" [ 
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  3 ❙  2 ❙  0 ❙  1 ❙  6
-                Blithering Badgers             ❙  2 ❙  1 ❙  1 ❙  0 ❙  4
-                Courageous Californians        ❙  2 ❙  0 ❙  1 ❙  1 ❙  1
-                Devastating Donkeys            ❙  1 ❙  0 ❙  0 ❙  1 ❙  0
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  3 |  2 |  0 |  1 |  6
+                Blithering Badgers             |  2 |  1 |  1 |  0 |  4
+                Courageous Californians        |  2 |  0 |  1 |  1 |  1
+                Devastating Donkeys            |  1 |  0 |  0 |  1 |  0
             }
             tally {
                 Allegoric Alaskans;Blithering Badgers;loss
@@ -140,11 +140,11 @@ describe "Tournament" [
     it.skip "ties broken alphabetically" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Allegoric Alaskans             ❙  3 ❙  2 ❙  1 ❙  0 ❙  7
-                Courageous Californians        ❙  3 ❙  2 ❙  1 ❙  0 ❙  7
-                Blithering Badgers             ❙  3 ❙  0 ❙  1 ❙  2 ❙  1
-                Devastating Donkeys            ❙  3 ❙  0 ❙  1 ❙  2 ❙  1
+                Team                           | MP |  W |  D |  L |  P
+                Allegoric Alaskans             |  3 |  2 |  1 |  0 |  7
+                Courageous Californians        |  3 |  2 |  1 |  0 |  7
+                Blithering Badgers             |  3 |  0 |  1 |  2 |  1
+                Devastating Donkeys            |  3 |  0 |  1 |  2 |  1
             }
             tally {
                 Courageous Californians;Devastating Donkeys;win
@@ -160,9 +160,9 @@ describe "Tournament" [
     it.skip "ensure points sorted numerically" [
         expects.be:'equal? @[
             {
-                Team                           ❙ MP ❙  W ❙  D ❙  L ❙  P
-                Devastating Donkeys            ❙  5 ❙  4 ❙  0 ❙  1 ❙ 12
-                Blithering Badgers             ❙  5 ❙  1 ❙  0 ❙  4 ❙  3
+                Team                           | MP |  W |  D |  L |  P
+                Devastating Donkeys            |  5 |  4 |  0 |  1 | 12
+                Blithering Badgers             |  5 |  1 |  0 |  4 |  3
             }
             tally {
                 Devastating Donkeys;Blithering Badgers;win


### PR DESCRIPTION
This reverts [this change](https://github.com/exercism/arturo/pull/198/commits/9520fef1f38923518d1d5ae0c4f2de012f24df02)