### PR TITLE
Replace master with latest in URLs

### DIFF
--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -3,5 +3,5 @@
 * [Arturo In A Nutshell][nutshell] is a concise "Learn X in Y Minutes"-style overview of basic Arturo syntax and features
 * [Rosetta Code][rosetta-code] has over 770+ Arturo code examples for many different tasks.
 
-[nutshell]: https://arturo-lang.io/master/documentation/in-a-nutshell/
+[nutshell]: https://arturo-lang.io/latest/documentation/in-a-nutshell/
 [rosetta-code]: https://rosettacode.org/wiki/Category:Arturo

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -5,7 +5,7 @@
 * [Rosetta Code][rosetta-code] has over 770+ Arturo code examples for many different tasks.
 * [Packager][packager] is Arturo's official package registry.
 
-[official-docs]: https://arturo-lang.io/master/documentation/
+[official-docs]: https://arturo-lang.io/latest/documentation/
 [discord]: https://discord.gg/YdVK2CB
 [packager]: https://pkgr.art/
 [rosetta-code]: https://rosettacode.org/wiki/Category:Arturo

--- a/exercises/practice/meetup/.docs/hints.md
+++ b/exercises/practice/meetup/.docs/hints.md
@@ -7,7 +7,7 @@
 * Examples of [formatting and parsing][example] dates.
 * The [`to`][to] function in the Types module is key.
 
-[lang]: https://arturo-lang.io/master/documentation/language/#date
-[dates]: https://arturo-lang.io/master/documentation/library/dates/
-[example]: https://arturo-lang.io/master/documentation/library/dates/#date-formatting-and-parsing
-[to]: https://arturo-lang.io/master/documentation/library/types/to/
+[lang]: https://arturo-lang.io/latest/documentation/language/#date
+[dates]: https://arturo-lang.io/latest/documentation/library/dates/
+[example]: https://arturo-lang.io/latest/documentation/library/dates/#date-formatting-and-parsing
+[to]: https://arturo-lang.io/latest/documentation/library/types/to/

--- a/exercises/practice/roman-numerals/.docs/instructions.append.md
+++ b/exercises/practice/roman-numerals/.docs/instructions.append.md
@@ -47,5 +47,5 @@ If you need to refer back to attributes, capture them at the start of your funct
 [createAttrsStack]: https://github.com/arturo-lang/arturo/blob/2ef0081570feb6ab752404c32bbf85132df379fb/src/vm/stack.nim#L136
 ~~~~
 
-[attributes]: https://arturo-lang.io/master/documentation/language/#attributes
-[attr]: https://arturo-lang.io/master/documentation/library/reflection/attr/
+[attributes]: https://arturo-lang.io/latest/documentation/language/#attributes
+[attr]: https://arturo-lang.io/latest/documentation/library/reflection/attr/

--- a/exercises/practice/space-age/.docs/instructions.append.md
+++ b/exercises/practice/space-age/.docs/instructions.append.md
@@ -38,7 +38,7 @@ length: convert 1`m `ft ; 1250/381 ft
 to :floating length ; 3.280839895013123
 ```
 
-[to]: https://arturo-lang.io/master/documentation/library/types/to/
+[to]: https://arturo-lang.io/latest/documentation/library/types/to/
 ~~~~
 
 Arturo also allows us to [specify] our own units for quantities.
@@ -52,7 +52,7 @@ depth: 20000`lea
 convert depth `km ; 111355.7993425152 km
 ```
 
-[physical-quantities]: https://en.wikipedia.org/wiki/Physical_quantity  
+[physical-quantities]: https://en.wikipedia.org/wiki/Physical_quantity
 [unit-of-measurement]: https://en.wikipedia.org/wiki/Unit_of_measurement
-[convert]: https://arturo-lang.io/master/documentation/library/quantities/convert/
-[specify]: https://arturo-lang.io/master/documentation/library/quantities/specify/
+[convert]: https://arturo-lang.io/latest/documentation/library/quantities/convert/
+[specify]: https://arturo-lang.io/latest/documentation/library/quantities/specify/

--- a/exercises/practice/tournament/.docs/instructions.append.md
+++ b/exercises/practice/tournament/.docs/instructions.append.md
@@ -9,8 +9,8 @@ You'll see some syntax in the tests that may be new to you: multiline strings en
 * [`:string` type][string] in the Language reference.
 * [Basic Usage][usage] documentation in the Strings module.
 
-[string]: https://arturo-lang.io/master/documentation/language/#string
-[usage]: https://arturo-lang.io/master/documentation/library/strings/#basic-usage
+[string]: https://arturo-lang.io/latest/documentation/language/#string
+[usage]: https://arturo-lang.io/latest/documentation/library/strings/#basic-usage
 
 ### Arturo string literals
 

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -6,6 +6,6 @@ Here are some resources for getting help if you run into trouble
 * [Arturo Discord][discord] is Arturo's official Discord server.
 * [Rosetta Code][rosetta-code] has over 770+ Arturo code examples for many different tasks.
 
-[official-docs]: https://arturo-lang.io/master/documentation/
+[official-docs]: https://arturo-lang.io/latest/documentation/
 [discord]: https://discord.gg/YdVK2CB
 [rosetta-code]: https://rosettacode.org/wiki/Category:Arturo


### PR DESCRIPTION
The Arturo nightly release docs are at https://arturo-lang.io/latest/, not https://arturo-lang.io/master/