### PR TITLE
Update install-arturo

### DIFF
--- a/bin/install-arturo
+++ b/bin/install-arturo
@@ -3,9 +3,6 @@
 # Synopsis:
 # Install arturo
 
-# We currently install the nightly version as that has features we use.
-# Once the next stable version has been released, we can use that.
-
 curl -sSL https://get.arturo-lang.io | sh
 
 function update_shell {


### PR DESCRIPTION
The current installer script should be enough. If we end up needing the very latest nightly, we could simply do:
```bash
curl -sSL https://get.arturo-lang.io/latest | sh
```
instead. 😉 
