### PR TITLE
Fix out-of-date OS detection in tester.art

### DIFF
--- a/bin/add-exercise
+++ b/bin/add-exercise
@@ -55,7 +55,7 @@ END_UNITT_TOML
 
 cat << END_TESTER > "exercises/practice/${slug}/tester.art"
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/acronym/tester.art
+++ b/exercises/practice/acronym/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/all-your-base/tester.art
+++ b/exercises/practice/all-your-base/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/allergies/tester.art
+++ b/exercises/practice/allergies/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/anagram/tester.art
+++ b/exercises/practice/anagram/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/armstrong-numbers/tester.art
+++ b/exercises/practice/armstrong-numbers/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/atbash-cipher/tester.art
+++ b/exercises/practice/atbash-cipher/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/binary-search/tester.art
+++ b/exercises/practice/binary-search/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/bob/tester.art
+++ b/exercises/practice/bob/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/bottle-song/tester.art
+++ b/exercises/practice/bottle-song/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/change/tester.art
+++ b/exercises/practice/change/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/clock/tester.art
+++ b/exercises/practice/clock/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/collatz-conjecture/tester.art
+++ b/exercises/practice/collatz-conjecture/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/darts/tester.art
+++ b/exercises/practice/darts/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/diamond/tester.art
+++ b/exercises/practice/diamond/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/difference-of-squares/tester.art
+++ b/exercises/practice/difference-of-squares/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/dnd-character/tester.art
+++ b/exercises/practice/dnd-character/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/eliuds-eggs/tester.art
+++ b/exercises/practice/eliuds-eggs/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/etl/tester.art
+++ b/exercises/practice/etl/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/flatten-array/tester.art
+++ b/exercises/practice/flatten-array/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/flower-field/tester.art
+++ b/exercises/practice/flower-field/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/food-chain/tester.art
+++ b/exercises/practice/food-chain/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/game-of-life/tester.art
+++ b/exercises/practice/game-of-life/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/gigasecond/tester.art
+++ b/exercises/practice/gigasecond/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/grains/tester.art
+++ b/exercises/practice/grains/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/hamming/tester.art
+++ b/exercises/practice/hamming/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/hello-world/tester.art
+++ b/exercises/practice/hello-world/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/high-scores/tester.art
+++ b/exercises/practice/high-scores/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/house/tester.art
+++ b/exercises/practice/house/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/isbn-verifier/tester.art
+++ b/exercises/practice/isbn-verifier/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/isogram/tester.art
+++ b/exercises/practice/isogram/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/kindergarten-garden/tester.art
+++ b/exercises/practice/kindergarten-garden/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/largest-series-product/tester.art
+++ b/exercises/practice/largest-series-product/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/leap/tester.art
+++ b/exercises/practice/leap/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/line-up/tester.art
+++ b/exercises/practice/line-up/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/luhn/tester.art
+++ b/exercises/practice/luhn/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/matching-brackets/tester.art
+++ b/exercises/practice/matching-brackets/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/matrix/tester.art
+++ b/exercises/practice/matrix/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/meetup/tester.art
+++ b/exercises/practice/meetup/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/nth-prime/tester.art
+++ b/exercises/practice/nth-prime/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/nucleotide-count/tester.art
+++ b/exercises/practice/nucleotide-count/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/pangram/tester.art
+++ b/exercises/practice/pangram/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/pascals-triangle/tester.art
+++ b/exercises/practice/pascals-triangle/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/perfect-numbers/tester.art
+++ b/exercises/practice/perfect-numbers/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/phone-number/tester.art
+++ b/exercises/practice/phone-number/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/pig-latin/tester.art
+++ b/exercises/practice/pig-latin/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/prime-factors/tester.art
+++ b/exercises/practice/prime-factors/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/prism/tester.art
+++ b/exercises/practice/prism/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/protein-translation/tester.art
+++ b/exercises/practice/protein-translation/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/proverb/tester.art
+++ b/exercises/practice/proverb/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/queen-attack/tester.art
+++ b/exercises/practice/queen-attack/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/raindrops/tester.art
+++ b/exercises/practice/raindrops/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/relative-distance/tester.art
+++ b/exercises/practice/relative-distance/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/resistor-color-duo/tester.art
+++ b/exercises/practice/resistor-color-duo/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/resistor-color/tester.art
+++ b/exercises/practice/resistor-color/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/reverse-string/tester.art
+++ b/exercises/practice/reverse-string/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/rna-transcription/tester.art
+++ b/exercises/practice/rna-transcription/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/robot-simulator/tester.art
+++ b/exercises/practice/robot-simulator/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/roman-numerals/tester.art
+++ b/exercises/practice/roman-numerals/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/rotational-cipher/tester.art
+++ b/exercises/practice/rotational-cipher/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/run-length-encoding/tester.art
+++ b/exercises/practice/run-length-encoding/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/scrabble-score/tester.art
+++ b/exercises/practice/scrabble-score/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/secret-handshake/tester.art
+++ b/exercises/practice/secret-handshake/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/series/tester.art
+++ b/exercises/practice/series/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/sieve/tester.art
+++ b/exercises/practice/sieve/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/space-age/tester.art
+++ b/exercises/practice/space-age/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/spiral-matrix/tester.art
+++ b/exercises/practice/spiral-matrix/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/square-root/tester.art
+++ b/exercises/practice/square-root/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/strain/tester.art
+++ b/exercises/practice/strain/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/sublist/tester.art
+++ b/exercises/practice/sublist/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/sum-of-multiples/tester.art
+++ b/exercises/practice/sum-of-multiples/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/tournament/tester.art
+++ b/exercises/practice/tournament/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/transpose/tester.art
+++ b/exercises/practice/transpose/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/triangle/tester.art
+++ b/exercises/practice/triangle/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/twelve-days/tester.art
+++ b/exercises/practice/twelve-days/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/two-bucket/tester.art
+++ b/exercises/practice/two-bucket/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/two-fer/tester.art
+++ b/exercises/practice/two-fer/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/word-count/tester.art
+++ b/exercises/practice/word-count/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 

--- a/exercises/practice/yacht/tester.art
+++ b/exercises/practice/yacht/tester.art
@@ -1,5 +1,5 @@
 execute ~{|sys\binary| -p install unitt 3.0.0}
-exe: switch "windows" = sys\os 
+exe: switch 'windows = sys\os 
     -> "unitt.bat" 
     -> "unitt"
 


### PR DESCRIPTION
Related to https://github.com/arturo-lang/arturo/issues/2030.

When Arturo 0.10.0 Arizona Bark was released, `sys\os` was updated to return a literal instead of a string. Windows requires special handling on how to call the Unitt testing framework so this was failing specifically for students on Windows. A follow-up PR will add a Windows runner to this track's CI to avoid this issue in the future.